### PR TITLE
Tsweb 1838,1840 upd tests for footer

### DIFF
--- a/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
+++ b/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
@@ -8,6 +8,7 @@ import {urlsWithoutCookiesMessage} from '../../preconditionsData/UrlPrecondition
 import UrlUtils from '../../utils/UrlUtils';
 import Footer from '../../identifiers/Footer';
 import UrlPath from '../../providers/UrlPath';
+import {stringUtils} from '../../utils/StringUtils';
 
 class BaseDriverSteps {
 	public async createsNewBrowser(browserName: BrowsersEnum = BrowsersEnum.DEFAULT_BROWSER) {
@@ -171,18 +172,24 @@ class BaseDriverSteps {
 	}
 
 	public async checkContactsEmail(contactBlock: Locator, expectedText: string) {
-		expect((await contactBlock.getByTestId(Footer.Email).innerText())!.replace(/\n/g, '')).toEqual(expectedText);
+		expect(stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(Footer.Email).innerText())).toEqual(
+			expectedText
+		);
 		expect(await contactBlock.getByTestId(Footer.EmailLink).getAttribute('href')).toBe(UrlPath.Email);
 	}
 
 	public async checkContactsPhone(contactBlock: Locator, expectedText: string) {
-		expect((await contactBlock.getByTestId(Footer.Phone).innerText())!.replace(/\n/g, '')).toEqual(expectedText);
-		expect((await contactBlock.getByTestId(Footer.PhoneUSALink).getAttribute('href'))!.replace(/-/g, '')).toBe(
-			UrlPath.PhoneUSA
+		expect(stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(Footer.Phone).innerText())).toEqual(
+			expectedText
 		);
-		expect((await contactBlock.getByTestId(Footer.PhoneEULink).getAttribute('href'))!.replace(/-/g, '')).toBe(
-			UrlPath.PhoneEU
-		);
+		expect(
+			stringUtils.removeHyphenCharachters(
+				await contactBlock.getByTestId(Footer.PhoneUSALink).getAttribute('href')
+			)
+		).toBe(UrlPath.PhoneUSA);
+		expect(
+			stringUtils.removeHyphenCharachters(await contactBlock.getByTestId(Footer.PhoneEULink).getAttribute('href'))
+		).toBe(UrlPath.PhoneEU);
 	}
 
 	public async checkFaqSectionsExpandingAndCollapsing(container: Locator, numberOfSections: number) {

--- a/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
+++ b/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
@@ -6,6 +6,8 @@ import Buttons from '../../identifiers/Buttons';
 import {playwrightUtils} from '../../utils/PlaywrightUtils';
 import {urlsWithoutCookiesMessage} from '../../preconditionsData/UrlPreconditions';
 import UrlUtils from '../../utils/UrlUtils';
+import Footer from '../../identifiers/Footer';
+import UrlPath from '../../providers/UrlPath';
 
 class BaseDriverSteps {
 	public async createsNewBrowser(browserName: BrowsersEnum = BrowsersEnum.DEFAULT_BROWSER) {
@@ -166,6 +168,21 @@ class BaseDriverSteps {
 		const expectedUrlClean = expectedUrlArray.filter((urlPart) => !ignorePatterns.includes(urlPart));
 		const isLinkPresent = expectedUrlClean.every((urlPart) => actualUrl.includes(urlPart));
 		return isLinkPresent;
+	}
+
+	public async checkContactsEmail(contactBlock: Locator, expectedText: string) {
+		expect((await contactBlock.getByTestId(Footer.Email).innerText())!.replace(/\n/g, '')).toEqual(expectedText);
+		expect(await contactBlock.getByTestId(Footer.EmailLink).getAttribute('href')).toBe(UrlPath.Email);
+	}
+
+	public async checkContactsPhone(contactBlock: Locator, expectedText: string) {
+		expect((await contactBlock.getByTestId(Footer.Phone).innerText())!.replace(/\n/g, '')).toEqual(expectedText);
+		expect((await contactBlock.getByTestId(Footer.PhoneUSALink).getAttribute('href'))!.replace(/-/g, '')).toBe(
+			UrlPath.PhoneUSA
+		);
+		expect((await contactBlock.getByTestId(Footer.PhoneEULink).getAttribute('href'))!.replace(/-/g, '')).toBe(
+			UrlPath.PhoneEU
+		);
 	}
 
 	public async checkFaqSectionsExpandingAndCollapsing(container: Locator, numberOfSections: number) {

--- a/ui_tests_playwright/automation/enum/IndustriesEnum.ts
+++ b/ui_tests_playwright/automation/enum/IndustriesEnum.ts
@@ -2,5 +2,4 @@ export enum IndustriesEnum {
 	Healthcare,
 	TransportAndLogist,
 	RenewableEnergy,
-	Startups,
 }

--- a/ui_tests_playwright/automation/enum/IndustriesEnum.ts
+++ b/ui_tests_playwright/automation/enum/IndustriesEnum.ts
@@ -2,4 +2,5 @@ export enum IndustriesEnum {
 	Healthcare,
 	TransportAndLogist,
 	RenewableEnergy,
+	Startups,
 }

--- a/ui_tests_playwright/automation/identifiers/Buttons.ts
+++ b/ui_tests_playwright/automation/identifiers/Buttons.ts
@@ -22,6 +22,7 @@ export default class Buttons {
 		Healthcare: 'Industries-Healthcare',
 		TransportationAndLogistics: 'Industries-TransportationAndLogistics',
 		RenewableEnergy: 'Industries-RenewableEnergy',
+		Startups: 'Industries-Startups',
 	};
 	static Expertise = {
 		CloudDev: 'Services-CloudDev',

--- a/ui_tests_playwright/automation/identifiers/Footer.ts
+++ b/ui_tests_playwright/automation/identifiers/Footer.ts
@@ -20,4 +20,10 @@ export default class Footer {
 	static CookiesPolicy = 'Button-CookiesPolicy';
 	static Sitemap = 'Button-Sitemap';
 	static ContactUs = 'Button-ContactUs';
+
+	//Contacs
+	static PhoneUSALink = 'Contacts-Phone-USA-Link';
+	static PhoneEULink = 'Contacts-Phone-EU-Link';
+	static Email = 'Contacts-Email';
+	static EmailLink = 'Contacts-Email-Link';
 }

--- a/ui_tests_playwright/automation/preconditionsData/UrlPreconditions.ts
+++ b/ui_tests_playwright/automation/preconditionsData/UrlPreconditions.ts
@@ -9,7 +9,6 @@ export const industryUrl: Record<IndustriesEnum, string> = {
 	[IndustriesEnum.Healthcare]: UrlProvider.urlBuilder(UrlPath.Healthcare),
 	[IndustriesEnum.TransportAndLogist]: UrlProvider.urlBuilder(UrlPath.TransportAndLogist),
 	[IndustriesEnum.RenewableEnergy]: UrlProvider.urlBuilder(UrlPath.RenewableEnergy),
-	[IndustriesEnum.Startups]: UrlProvider.urlBuilder(UrlPath.Startups),
 };
 
 export const serviceUrl: Record<ServicesEnum, string> = {

--- a/ui_tests_playwright/automation/preconditionsData/UrlPreconditions.ts
+++ b/ui_tests_playwright/automation/preconditionsData/UrlPreconditions.ts
@@ -9,6 +9,7 @@ export const industryUrl: Record<IndustriesEnum, string> = {
 	[IndustriesEnum.Healthcare]: UrlProvider.urlBuilder(UrlPath.Healthcare),
 	[IndustriesEnum.TransportAndLogist]: UrlProvider.urlBuilder(UrlPath.TransportAndLogist),
 	[IndustriesEnum.RenewableEnergy]: UrlProvider.urlBuilder(UrlPath.RenewableEnergy),
+	[IndustriesEnum.Startups]: UrlProvider.urlBuilder(UrlPath.Startups),
 };
 
 export const serviceUrl: Record<ServicesEnum, string> = {
@@ -69,6 +70,7 @@ export const webflowPages: string[] = [
 	UrlProvider.urlBuilder(UrlPath.CloudMigration),
 	UrlProvider.urlBuilder(UrlPath.DedicatedTeam),
 	UrlProvider.urlBuilder(UrlPath.StaffAugmentation),
+	UrlProvider.urlBuilder(UrlPath.Startups),
 	UrlProvider.urlBuilder(UrlPath.ComputerVision),
 	UrlProvider.urlBuilder(UrlPath.OpenAI),
 	UrlProvider.urlBuilder(UrlPath.DeepLearning),

--- a/ui_tests_playwright/automation/providers/UrlPath.ts
+++ b/ui_tests_playwright/automation/providers/UrlPath.ts
@@ -3,6 +3,7 @@ export default class UrlPath {
 	static Healthcare = 'industries/healthcare';
 	static TransportAndLogist = 'industries/transportation-and-logistics';
 	static RenewableEnergy = 'industries/renewable-energy';
+	static Startups = 'startups';
 
 	// Services pages
 	static OurServices = 'services';
@@ -29,8 +30,8 @@ export default class UrlPath {
 	static AiIntegrationServices = 'services/ai-integration';
 	static DataStrategy = 'services/data-strategy-consulting';
 	static ComputerVision = 'services/computer-vision-development';
- 	static OpenAI = 'services/openai-api-integration';
- 	static DeepLearning = 'services/deep-learning-development';
+	static OpenAI = 'services/openai-api-integration';
+	static DeepLearning = 'services/deep-learning-development';
 
 	// Company pages
 	static AboutUs = 'about-us';
@@ -63,4 +64,9 @@ export default class UrlPath {
 
 	// Error pages
 	static PageNotFound = '404';
+
+	//Contacs
+	static PhoneUSA = 'tel:+13124420823';
+	static PhoneEU = 'tel:+48717353668';
+	static Email = 'mailto:hello@tech-stack.com';
 }

--- a/ui_tests_playwright/automation/test/ui/generalComponents/footer/FooterWorldwide.test.ts
+++ b/ui_tests_playwright/automation/test/ui/generalComponents/footer/FooterWorldwide.test.ts
@@ -34,7 +34,9 @@ let servicesBlock: Locator;
 
 const testDataProvider: string[] = [
 	UrlProvider.webSiteUrl(),
-	UrlUtils.getRandomUrlFromArray(Object.values(industryUrl)),
+	UrlUtils.getRandomUrlFromArray(
+		Object.values(industryUrl).filter((value) => value !== UrlProvider.urlBuilder(UrlPath.Startups))
+	),
 	UrlUtils.getRandomUrlFromArray(Object.values(serviceUrl)),
 	UrlUtils.getRandomUrlFromArray(Object.values(expertiseUrl)),
 	UrlProvider.urlBuilder(UrlUtils.getRandomUrlFromArray([UrlPath.AboutUs, UrlPath.HowWeWork, UrlPath.OurClients])),
@@ -65,7 +67,7 @@ test.beforeEach(async () => {
 	servicesBlock = footer.getByTestId(Footer.ServicesBlock);
 });
 
-test.skip(
+test(
 	qase(
 		5485,
 		`Check the footer information from the "Footer" container on all pages @desktop @mobile @Regression @Footer @TSWEB-655 @TSWEB-674`
@@ -81,8 +83,11 @@ test.skip(
 			const headquoters = 'Headquarters:';
 			const countryData = 'Poland, Wroclaw,';
 			const streetData = '9 Rybacka street, 53-656';
-			const phoneNumber = 'Phone number:';
-			const phoneNumberData = '+1-312-442-0823';
+			const callUs = 'Call us:';
+			const phoneNumberDataUSA = '+1-312-442-0823 (USA)';
+			const phoneNumberDataEU = '+4-871-735-3668 (EU)';
+			const sayHi = 'Say hi:';
+			const email = 'hello@tech-stack.com';
 
 			await expect(footer.getByTestId(Buttons.Logo)).toBeVisible();
 			await expect(contactBlock.getByTestId(Container.SectionTitle)).toHaveText('Contacts');
@@ -91,19 +96,18 @@ test.skip(
 				await expect(contactBlock.getByTestId(Footer.Headquarters)).toHaveText(
 					`${headquoters}${countryData}\n${streetData}`
 				);
-				await expect(contactBlock.getByTestId(Footer.Phone)).toHaveText(`${phoneNumber}${phoneNumberData}`);
 			} else if (webflowPages.includes(url)) {
 				await expect(contactBlock.getByTestId(Footer.Headquarters)).toHaveText(
 					`${headquoters}${countryData} ${streetData}`
 				);
-				await expect(contactBlock.getByTestId(Footer.Phone)).toHaveText(`${phoneNumber}${phoneNumberData}`);
 			} else {
 				await expect(contactBlock.getByTestId(Footer.Headquarters)).toHaveText(
 					`${headquoters}\n${countryData}\n${streetData}`
 				);
-				await expect(contactBlock.getByTestId(Footer.Phone)).toHaveText(`${phoneNumber} ${phoneNumberData}`);
-				await expect(contactBlock.getByTestId(Footer.ContactUs)).toHaveText('Contact Us');
 			}
+
+			baseDriverSteps.checkContactsPhone(contactBlock, `${callUs}${phoneNumberDataUSA}${phoneNumberDataEU}`);
+			baseDriverSteps.checkContactsEmail(contactBlock, `${sayHi}${email}`);
 
 			await expect(footer.getByTestId(Footer.Info)).toHaveText(`© ${year} Techstack. All rights reserved.`);
 
@@ -114,11 +118,11 @@ test.skip(
 				'AI Integration Services',
 				'Data Strategy',
 				'Software Audit',
-				'QA as a Service',
+				'Quality Assurance',
 				'Product Scaling',
 				'Cloud Migration',
 				'Dedicated Team',
-				'Staff Augmentation',
+				'Expert Outstaffing',
 			];
 
 			for (let index = 0; index < servicesUrls.length; index++) {
@@ -127,7 +131,7 @@ test.skip(
 			}
 
 			await expect(industriesBlock.getByTestId(Container.BlockTitle)).toHaveText('Industries');
-			const industriesText = ['Healthcare', 'Transportation and Logistics', 'Renewable Energy'];
+			const industriesText = ['Healthcare', 'Transportation and Logistics', 'Renewable Energy', 'Startups'];
 
 			for (let index = 0; index < industriesUrls.length; index++) {
 				const button = footer.getByTestId(Object.values(industriesButtons)[index]);

--- a/ui_tests_playwright/automation/test/ui/generalComponents/footer/FooterWorldwide.test.ts
+++ b/ui_tests_playwright/automation/test/ui/generalComponents/footer/FooterWorldwide.test.ts
@@ -34,9 +34,7 @@ let servicesBlock: Locator;
 
 const testDataProvider: string[] = [
 	UrlProvider.webSiteUrl(),
-	UrlUtils.getRandomUrlFromArray(
-		Object.values(industryUrl).filter((value) => value !== UrlProvider.urlBuilder(UrlPath.Startups))
-	),
+	UrlUtils.getRandomUrlFromArray(Object.values(industryUrl)),
 	UrlUtils.getRandomUrlFromArray(Object.values(serviceUrl)),
 	UrlUtils.getRandomUrlFromArray(Object.values(expertiseUrl)),
 	UrlProvider.urlBuilder(UrlUtils.getRandomUrlFromArray([UrlPath.AboutUs, UrlPath.HowWeWork, UrlPath.OurClients])),
@@ -248,6 +246,9 @@ test(
 				await baseDriverSteps.checkUrl(industriesUrls[index]);
 				await baseDriverSteps.goToUrl(url);
 			}
+			await footer.getByTestId(Object.values(industriesButtons).slice(-1)[0]).click();
+			await baseDriverSteps.checkUrl(UrlProvider.urlBuilder(UrlPath.Startups));
+			await baseDriverSteps.goToUrl(url);
 		}
 	}
 );

--- a/ui_tests_playwright/automation/utils/StringUtils.ts
+++ b/ui_tests_playwright/automation/utils/StringUtils.ts
@@ -2,6 +2,14 @@ class StringUtils {
 	public encodeForUrl(text: string): string {
 		return encodeURIComponent(text).replace(/%20|%0A|%C2%A0/g, '-');
 	}
+
+	public removeNewLineCharachters(text: string | null): string {
+		return text!.replace(/\n/g, '');
+	}
+
+	public removeHyphenCharachters(text: string | null): string {
+		return text!.replace(/-/g, '');
+	}
 }
 
 const stringUtils = new StringUtils();


### PR DESCRIPTION
Updated tests for these footer changes:
- Add Startup link to Industry column

- Replace the names of the pages:  Staff augmentation → Expert Outstaffing and QA as a Service → Quality Assurance

- Change contacts block (add additional number, change email text and make them clickable)

