### PR TITLE
Update checkRedirectToPage step

### DIFF
--- a/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
+++ b/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
@@ -135,7 +135,6 @@ class BaseDriverSteps {
 			await driver.Page.waitForLoadState();
 		} else {
 			const [newPage] = await Promise.all([driver.DriverContext.waitForEvent('page'), locator.click()]);
-			await newPage.waitForLoadState();
 			await playwrightUtils.expectWithRetries(
 				async () => {
 					expect(this.checkLinksEquality(expectedUrl, newPage.url())).toBeTruthy();


### PR DESCRIPTION
Fix for the inconsistent test 'Check redirect by card in "Recognition and Media Presence" container from the "Home" page', which uses checkRedirectToPage step
page.waitForLoadState can return error for outside urls - https://tech-stack-dev.github.io/ts-website-automation/ui_tests_playwright/automation/reports/pull-requests/2024-11-25/14-09-58/index.html#?testId=bcf64d15a640789472ba-ca5d801034b58249fe19
 