### PR TITLE
Add test for Calendly section in forms

### DIFF
--- a/ui_tests_playwright/automation/dto/ExpertDto.ts
+++ b/ui_tests_playwright/automation/dto/ExpertDto.ts
@@ -1,0 +1,55 @@
+import UrlPath from "../providers/UrlPath";
+import UrlProvider from "../providers/UrlProvider";
+
+export interface ExpertDto {
+	name: string;
+	role: string;
+	pages: string[];
+}
+
+export const allExpertsList: ExpertDto[] = [
+	{
+		name: 'Max Levytsky',
+		role: 'Managing Partner',
+		pages: [
+			UrlProvider.webSiteUrl(),
+			UrlProvider.urlBuilder(UrlPath.DevOpsServ),
+			UrlProvider.urlBuilder(UrlPath.InternetOfThings),
+			UrlProvider.urlBuilder(UrlPath.AiDevelopment),
+			UrlProvider.urlBuilder(UrlPath.AboutUs),
+		],
+	},
+	{
+		name: 'Anzhelika Grebennikova',
+		role: 'Global Partnership Manager',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.Healthcare),
+			UrlProvider.urlBuilder(UrlPath.RenewableEnergy),
+			UrlProvider.urlBuilder(UrlPath.TransportAndLogist),
+		],
+	},
+	{
+		name: 'Anton Ivanchenko',
+		role: 'Business Development Manager',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.UiUxDesign),
+			UrlProvider.urlBuilder(UrlPath.MobileDev),
+			UrlProvider.urlBuilder(UrlPath.BigData),
+			UrlProvider.urlBuilder(UrlPath.HowWeWork),
+			UrlProvider.urlBuilder(UrlPath.Pricing),
+			UrlProvider.urlBuilder(UrlPath.ConsultingServ),
+		],
+	},
+	{
+		name: 'Artem Marynych',
+		role: 'Chief Growth Officer',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.CloudDevelopment),
+			UrlProvider.urlBuilder(UrlPath.DigitalTransform),
+			UrlProvider.urlBuilder(UrlPath.FrontEndDevelopment),
+			UrlProvider.urlBuilder(UrlPath.BackEndDevelopment),
+			UrlProvider.urlBuilder(UrlPath.QaAsAServ),
+			UrlProvider.urlBuilder(UrlPath.CustomDev),
+		],
+	},
+];

--- a/ui_tests_playwright/automation/identifiers/Container.ts
+++ b/ui_tests_playwright/automation/identifiers/Container.ts
@@ -25,6 +25,7 @@ export default class Container {
 	static MemberCard = 'MemberCard';
 	static MemberRole = 'MemberRole';
 	static MemberName = 'MemberName';
+	static MemberImage = 'MemberImage';
 
 	static AuthorName = 'AuthorName';
 	static AuthorPosition = 'AuthorPosition';

--- a/ui_tests_playwright/automation/steps/ui/CalendlySteps.ts
+++ b/ui_tests_playwright/automation/steps/ui/CalendlySteps.ts
@@ -6,7 +6,7 @@ import {baseDriverSteps} from '../../base/step/BaseDriverSteps';
 import Calendly from '../../identifiers/mainSite/Calendly';
 
 class CalendlySteps {
-	public async checkMemberCardCalendly(memberCard: Locator | undefined, memberData: {name: string; role: string}) {
+	public async checkMemberCardCalendly(memberCard: Locator | null, memberData: {name: string; role: string}) {
 		if (!memberCard) {
 			throw new Error(`No card found for expert: ${memberData.name}`);
 		}
@@ -15,7 +15,7 @@ class CalendlySteps {
 		const name = memberCard.getByTestId(Container.MemberName);
 		const role = memberCard.getByTestId(Container.MemberRole);
 		const consultButton = memberCard.getByTestId(MainSiteButtons.ScheduleAConsultationInCalendly);
-		const image = memberCard.locator('.member-foto');
+		const image = memberCard.getByTestId(Container.MemberImage);
 
 		await expect(name).toHaveText(memberData.name);
 		await expect(role).toHaveText(memberData.role);
@@ -27,11 +27,12 @@ class CalendlySteps {
 	public async findMatchingMemberCardByName(cardElements: Locator[], expertName: string) {
 		for (const card of cardElements) {
 			const cardName = await card.getByTestId(Container.MemberName).textContent();
-			if (cardName === expertName) return card;
+
+			return cardName === expertName ? card : null;
 		}
 	}
 
-	public async checkAppropriateCalendlyModalOpensAndCloses(memberCard: Locator | undefined) {
+	public async checkAppropriateCalendlyModalOpensAndCloses(memberCard: Locator | null) {
 		if (!memberCard) {
 			throw new Error(`No card found`);
 		}

--- a/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
+++ b/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
@@ -6,38 +6,108 @@ import UrlProvider from '../../../../providers/UrlProvider';
 import Container from '../../../../identifiers/Container';
 import {calendlySteps} from '../../../../steps/ui/CalendlySteps';
 import GeneralContainersMainSite from '../../../../identifiers/mainSite/GeneralContainersMainSite';
+import UrlUtils from '../../../../utils/UrlUtils';
+
+interface ExpertData {
+	name: string;
+	role: string;
+	pages: string[];
+}
 
 let consultWithUsContainer: Locator;
+let getInTouchContainer: Locator;
 
 const testDataProvider: string[] = [
 	UrlProvider.urlBuilder(UrlPath.GetAQuote),
 	UrlProvider.urlBuilder(UrlPath.ContactUs),
 ];
 
+const allExperts: ExpertData[] = [
+	{
+		name: 'Max Levytsky',
+		role: 'Managing Partner',
+		pages: [
+			UrlProvider.webSiteUrl(),
+			UrlProvider.urlBuilder(UrlPath.DevOpsServ),
+			UrlProvider.urlBuilder(UrlPath.InternetOfThings),
+			UrlProvider.urlBuilder(UrlPath.AiDevelopment),
+			UrlProvider.urlBuilder(UrlPath.AboutUs),
+		],
+	},
+	{
+		name: 'Anzhelika Grebennikova',
+		role: 'Global Partnership Manager',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.Healthcare),
+			UrlProvider.urlBuilder(UrlPath.RenewableEnergy),
+			UrlProvider.urlBuilder(UrlPath.TransportAndLogist),
+		],
+	},
+	{
+		name: 'Anton Ivanchenko',
+		role: 'Business Development Manager',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.UiUxDesign),
+			UrlProvider.urlBuilder(UrlPath.MobileDev),
+			UrlProvider.urlBuilder(UrlPath.BigData),
+			UrlProvider.urlBuilder(UrlPath.HowWeWork),
+			UrlProvider.urlBuilder(UrlPath.Pricing),
+			UrlProvider.urlBuilder(UrlPath.ConsultingServ),
+		],
+	},
+	{
+		name: 'Artem Marynych',
+		role: 'Chief Growth Officer',
+		pages: [
+			UrlProvider.urlBuilder(UrlPath.CloudDevelopment),
+			UrlProvider.urlBuilder(UrlPath.DigitalTransform),
+			UrlProvider.urlBuilder(UrlPath.FrontEndDevelopment),
+			UrlProvider.urlBuilder(UrlPath.BackEndDevelopment),
+			UrlProvider.urlBuilder(UrlPath.QaAsAServ),
+			UrlProvider.urlBuilder(UrlPath.CustomDev),
+		],
+	},
+];
+
 test.beforeEach(async () => {
 	await baseDriverSteps.createsNewBrowser();
-	consultWithUsContainer = driver.getByTestId(GeneralContainersMainSite.ConsultWithUs);
 });
 
-test('Check member cards from from Calendly block on the "Contact us" and "Get a Quote" pages @desktop @mobile @Regression @Calendly @TSWEB-1852', async () => {
+test('Check expert cards from Calendly block on the "Contact us" and "Get a Quote" pages @desktop @mobile @Regression @Calendly @TSWEB-1852', async () => {
+	consultWithUsContainer = driver.getByTestId(GeneralContainersMainSite.ConsultWithUs);
+
 	for (const url of testDataProvider) {
 		await baseDriverSteps.goToUrl(url);
-
 		const cardElements = await consultWithUsContainer.getByTestId(Container.MemberCard).all();
 
-		const allExperts = [
+		const experts = [
 			{name: 'Max Levytskyi', role: 'Managing Partner'},
 			{name: 'Anton Ivanchenko', role: 'Business Development Manager'},
 			{name: 'Artem Marynych', role: 'Chief Growth Officer'},
 		];
 
-		expect(cardElements.length).toBe(allExperts.length);
-
-		for (const expertData of allExperts) {
+		expect(cardElements.length).toBe(3);
+		for (const expertData of experts) {
 			const matchingCard = await calendlySteps.findMatchingMemberCardByName(cardElements, expertData.name);
-			await calendlySteps.checkMemberCardCalendly(matchingCard, expertData);
-			await calendlySteps.checkAppropriateCalendlyModalOpensAndCloses(matchingCard);
+			if (matchingCard) {
+				await calendlySteps.checkMemberCardCalendly(matchingCard, expertData);
+				await calendlySteps.checkAppropriateCalendlyModalOpensAndCloses(matchingCard);
+			}
 		}
+	}
+});
+
+test('Check expert cards from Calendly section in forms on business website pages @desktop @mobile @Regression @TSWEB-1852', async () => {
+	getInTouchContainer = driver.getByTestId(GeneralContainersMainSite.GetInTouch);
+
+	for (const expert of allExperts) {
+		const url = UrlUtils.getRandomUrlFromArray(expert.pages);
+		await baseDriverSteps.goToUrl(url);
+		const memberCard = getInTouchContainer.getByTestId(Container.MemberCard);
+
+		await expect(memberCard).toHaveCount(1);
+		await calendlySteps.checkMemberCardCalendly(memberCard, expert);
+		await calendlySteps.checkAppropriateCalendlyModalOpensAndCloses(memberCard);
 	}
 });
 

--- a/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
+++ b/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
@@ -29,7 +29,9 @@ test('Check expert cards from Calendly block on the "Contact us" and "Get a Quot
 		const cardElements = await consultWithUsContainer.getByTestId(Container.MemberCard).all();
 		expect(cardElements.length).toBe(3);
 
-		for (const expertData of allExpertsList) {
+		// for (const expertData of allExpertsList) {
+		for (const originalExpertData of allExpertsList) {
+			const expertData = {...originalExpertData};
 			expertData.name = expertData.name === 'Max Levytsky' ? 'Max Levytskyi' : expertData.name;
 			const matchingCard = await calendlySteps.findMatchingMemberCardByName(cardElements, expertData.name);
 			if (matchingCard) {

--- a/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
+++ b/ui_tests_playwright/automation/test/ui/generalComponents/calendly/CalendlyBlockBusiness.test.ts
@@ -7,12 +7,7 @@ import Container from '../../../../identifiers/Container';
 import {calendlySteps} from '../../../../steps/ui/CalendlySteps';
 import GeneralContainersMainSite from '../../../../identifiers/mainSite/GeneralContainersMainSite';
 import UrlUtils from '../../../../utils/UrlUtils';
-
-interface ExpertData {
-	name: string;
-	role: string;
-	pages: string[];
-}
+import {allExpertsList} from '../../../../dto/ExpertDto';
 
 let consultWithUsContainer: Locator;
 let getInTouchContainer: Locator;
@@ -20,53 +15,6 @@ let getInTouchContainer: Locator;
 const testDataProvider: string[] = [
 	UrlProvider.urlBuilder(UrlPath.GetAQuote),
 	UrlProvider.urlBuilder(UrlPath.ContactUs),
-];
-
-const allExperts: ExpertData[] = [
-	{
-		name: 'Max Levytsky',
-		role: 'Managing Partner',
-		pages: [
-			UrlProvider.webSiteUrl(),
-			UrlProvider.urlBuilder(UrlPath.DevOpsServ),
-			UrlProvider.urlBuilder(UrlPath.InternetOfThings),
-			UrlProvider.urlBuilder(UrlPath.AiDevelopment),
-			UrlProvider.urlBuilder(UrlPath.AboutUs),
-		],
-	},
-	{
-		name: 'Anzhelika Grebennikova',
-		role: 'Global Partnership Manager',
-		pages: [
-			UrlProvider.urlBuilder(UrlPath.Healthcare),
-			UrlProvider.urlBuilder(UrlPath.RenewableEnergy),
-			UrlProvider.urlBuilder(UrlPath.TransportAndLogist),
-		],
-	},
-	{
-		name: 'Anton Ivanchenko',
-		role: 'Business Development Manager',
-		pages: [
-			UrlProvider.urlBuilder(UrlPath.UiUxDesign),
-			UrlProvider.urlBuilder(UrlPath.MobileDev),
-			UrlProvider.urlBuilder(UrlPath.BigData),
-			UrlProvider.urlBuilder(UrlPath.HowWeWork),
-			UrlProvider.urlBuilder(UrlPath.Pricing),
-			UrlProvider.urlBuilder(UrlPath.ConsultingServ),
-		],
-	},
-	{
-		name: 'Artem Marynych',
-		role: 'Chief Growth Officer',
-		pages: [
-			UrlProvider.urlBuilder(UrlPath.CloudDevelopment),
-			UrlProvider.urlBuilder(UrlPath.DigitalTransform),
-			UrlProvider.urlBuilder(UrlPath.FrontEndDevelopment),
-			UrlProvider.urlBuilder(UrlPath.BackEndDevelopment),
-			UrlProvider.urlBuilder(UrlPath.QaAsAServ),
-			UrlProvider.urlBuilder(UrlPath.CustomDev),
-		],
-	},
 ];
 
 test.beforeEach(async () => {
@@ -79,15 +27,10 @@ test('Check expert cards from Calendly block on the "Contact us" and "Get a Quot
 	for (const url of testDataProvider) {
 		await baseDriverSteps.goToUrl(url);
 		const cardElements = await consultWithUsContainer.getByTestId(Container.MemberCard).all();
-
-		const experts = [
-			{name: 'Max Levytskyi', role: 'Managing Partner'},
-			{name: 'Anton Ivanchenko', role: 'Business Development Manager'},
-			{name: 'Artem Marynych', role: 'Chief Growth Officer'},
-		];
-
 		expect(cardElements.length).toBe(3);
-		for (const expertData of experts) {
+
+		for (const expertData of allExpertsList) {
+			expertData.name = expertData.name === 'Max Levytsky' ? 'Max Levytskyi' : expertData.name;
 			const matchingCard = await calendlySteps.findMatchingMemberCardByName(cardElements, expertData.name);
 			if (matchingCard) {
 				await calendlySteps.checkMemberCardCalendly(matchingCard, expertData);
@@ -100,7 +43,7 @@ test('Check expert cards from Calendly block on the "Contact us" and "Get a Quot
 test('Check expert cards from Calendly section in forms on business website pages @desktop @mobile @Regression @TSWEB-1852', async () => {
 	getInTouchContainer = driver.getByTestId(GeneralContainersMainSite.GetInTouch);
 
-	for (const expert of allExperts) {
+	for (const expert of allExpertsList) {
 		const url = UrlUtils.getRandomUrlFromArray(expert.pages);
 		await baseDriverSteps.goToUrl(url);
 		const memberCard = getInTouchContainer.getByTestId(Container.MemberCard);


### PR DESCRIPTION
Add test to check expert cards from Calendly section in forms on business website pages. 
Implement possibility to use unified expert testdata for Calendly checks (can be used only after Max Levitskiy lastname is fixed throughout expert cards)