### PR TITLE
Update tests for Contact Us page 

### DIFF
--- a/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
+++ b/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
@@ -9,6 +9,7 @@ import UrlUtils from '../../utils/UrlUtils';
 import Footer from '../../identifiers/Footer';
 import UrlPath from '../../providers/UrlPath';
 import {stringUtils} from '../../utils/StringUtils';
+import ContactsBlock from '../../identifiers/mainSite/ContactsBlock';
 
 class BaseDriverSteps {
 	public async createsNewBrowser(browserName: BrowsersEnum = BrowsersEnum.DEFAULT_BROWSER) {
@@ -171,10 +172,10 @@ class BaseDriverSteps {
 	}
 
 	public async checkContactsEmail(contactBlock: Locator, expectedText: string) {
-		expect(stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(Footer.Email).innerText())).toEqual(
-			expectedText
-		);
-		expect(await contactBlock.getByTestId(Footer.EmailLink).getAttribute('href')).toBe(UrlPath.Email);
+		expect(
+			stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(ContactsBlock.Email).innerText())
+		).toEqual(expectedText);
+		expect(await contactBlock.getByTestId(ContactsBlock.EmailLink).getAttribute('href')).toBe(UrlPath.Email);
 	}
 
 	public async checkContactsPhone(contactBlock: Locator, expectedText: string) {
@@ -183,12 +184,19 @@ class BaseDriverSteps {
 		);
 		expect(
 			stringUtils.removeHyphenCharachters(
-				await contactBlock.getByTestId(Footer.PhoneUSALink).getAttribute('href')
+				await contactBlock.getByTestId(ContactsBlock.PhoneUSALink).getAttribute('href')
 			)
 		).toBe(UrlPath.PhoneUSA);
 		expect(
-			stringUtils.removeHyphenCharachters(await contactBlock.getByTestId(Footer.PhoneEULink).getAttribute('href'))
+			stringUtils.removeHyphenCharachters(
+				await contactBlock.getByTestId(ContactsBlock.PhoneEULink).getAttribute('href')
+			)
 		).toBe(UrlPath.PhoneEU);
+	}
+
+	public async checkClipBoardContect(expectedText: string) {
+		const clipboardContent = await driver.Page.evaluate('navigator.clipboard.readText()');
+		expect(clipboardContent).toBe(expectedText);
 	}
 
 	public async checkFaqSectionsExpandingAndCollapsing(container: Locator, numberOfSections: number) {

--- a/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
+++ b/ui_tests_playwright/automation/base/step/BaseDriverSteps.ts
@@ -179,7 +179,7 @@ class BaseDriverSteps {
 	}
 
 	public async checkContactsPhone(contactBlock: Locator, expectedText: string) {
-		expect(stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(Footer.Phone).innerText())).toEqual(
+		expect(stringUtils.removeNewLineCharachters(await contactBlock.getByTestId(ContactsBlock.Phone).innerText())).toEqual(
 			expectedText
 		);
 		expect(

--- a/ui_tests_playwright/automation/identifiers/Footer.ts
+++ b/ui_tests_playwright/automation/identifiers/Footer.ts
@@ -20,10 +20,4 @@ export default class Footer {
 	static CookiesPolicy = 'Button-CookiesPolicy';
 	static Sitemap = 'Button-Sitemap';
 	static ContactUs = 'Button-ContactUs';
-
-	//Contacs
-	static PhoneUSALink = 'Contacts-Phone-USA-Link';
-	static PhoneEULink = 'Contacts-Phone-EU-Link';
-	static Email = 'Contacts-Email';
-	static EmailLink = 'Contacts-Email-Link';
 }

--- a/ui_tests_playwright/automation/identifiers/Footer.ts
+++ b/ui_tests_playwright/automation/identifiers/Footer.ts
@@ -12,7 +12,6 @@ export default class Footer {
 	static CareerBlock = 'CareerBlock';
 
 	static Headquarters = 'Contacts-Headquarters';
-	static Phone = 'Contacts-Phone';
 	static Info = 'Info';
 
 	// Button

--- a/ui_tests_playwright/automation/identifiers/mainSite/ContactsBlock.ts
+++ b/ui_tests_playwright/automation/identifiers/mainSite/ContactsBlock.ts
@@ -1,4 +1,5 @@
 export default class ContactsBlock {
+	static Phone = 'Contacts-Phone';
 	static PhoneUSALink = 'Contacts-Phone-USA-Link';
 	static PhoneEULink = 'Contacts-Phone-EU-Link';
 	static Email = 'Contacts-Email';

--- a/ui_tests_playwright/automation/identifiers/mainSite/ContactsBlock.ts
+++ b/ui_tests_playwright/automation/identifiers/mainSite/ContactsBlock.ts
@@ -1,0 +1,8 @@
+export default class ContactsBlock {
+	static PhoneUSALink = 'Contacts-Phone-USA-Link';
+	static PhoneEULink = 'Contacts-Phone-EU-Link';
+	static Email = 'Contacts-Email';
+	static EmailLink = 'Contacts-Email-Link';
+	static CopyEmail = 'Contacts-Copy-Email';
+	static CopyEmailNotification = 'Contacts-Copy-Email-Notification';
+}

--- a/ui_tests_playwright/automation/identifiers/mainSite/pages/contactUs/ContactUs.ts
+++ b/ui_tests_playwright/automation/identifiers/mainSite/pages/contactUs/ContactUs.ts
@@ -1,7 +1,7 @@
 import GeneralContainersMainSite from '../../GeneralContainersMainSite';
 
 export default class ContactUs extends GeneralContainersMainSite {
-	static GetInTouchForm = 'Container-GetInTouchForm';
 	static ContactUs = 'Container-ContactUs';
+	static ContactUsForm = 'Container-ContactUsForm';
 	static Cooperation = 'Container-Cooperation';
 }

--- a/ui_tests_playwright/automation/test/ui/mainSite/contactUs/ContactUsPage.test.ts
+++ b/ui_tests_playwright/automation/test/ui/mainSite/contactUs/ContactUsPage.test.ts
@@ -7,6 +7,7 @@ import UrlPath from '../../../../providers/UrlPath';
 import UrlProvider from '../../../../providers/UrlProvider';
 import {qase} from 'playwright-qase-reporter/dist/playwright';
 import MainSiteImages from '../../../../identifiers/mainSite/MainSiteImages';
+import ContactsBlock from '../../../../identifiers/mainSite/ContactsBlock';
 
 test.beforeEach(async () => {
 	await baseDriverSteps.createsNewBrowserAndGoToUrl(UrlProvider.urlBuilder(UrlPath.ContactUs));
@@ -20,29 +21,48 @@ test(
 	}
 );
 
-test.skip(
+test(
 	qase(
 		4974,
 		'Check the container title and number from the "Contact Us" page @desktop @mobile @Regression @ContactUs @TSWEB-148 @TSWEB-1082'
 	),
 	async () => {
 		const containers = [
-			driver.getByTestId(ContactUs.ContactUs),
+			driver.getByTestId(ContactUs.ContactUsForm),
 			driver.getByTestId(ContactUs.ConsultWithUs),
 			driver.getByTestId(ContactUs.TrustedBy),
 			driver.getByTestId(ContactUs.Cooperation),
 		];
 
 		const expectedData = [
-			['Contact Us', '01'],
+			['Get in Touch', '01'],
 			['Consult with us', '02'],
 			['Trusted By', '03'],
-			['Cooperation Contacts', '04'],
+			['Cooperation', '04'],
 		];
 
 		await baseDriverSteps.checkContainerTitlesAndNumbers(containers, expectedData);
 	}
 );
+
+test('Check contact information in "Get in Touch" container from the "Contact Us" page @desktop @mobile @Regression @ContactUs @TSWEB-1833', async () => {
+	let contactUsForm = driver.getByTestId(ContactUs.ContactUsForm);
+	let copyIcon = driver.getByTestId(ContactsBlock.CopyEmail);
+	let notification = driver.getByTestId(ContactsBlock.CopyEmailNotification);
+	const callUs = 'Call us';
+	const phoneNumberDataUSA = '+1-312-442-0823 (USA)';
+	const phoneNumberDataEU = '+4-871-735-3668 (EU)';
+	const sayHi = 'Say hi';
+	const email = 'hello@tech-stack.com';
+
+	baseDriverSteps.checkContactsPhone(contactUsForm, `${callUs}${phoneNumberDataUSA}${phoneNumberDataEU}`);
+	baseDriverSteps.checkContactsEmail(contactUsForm, `${sayHi}${email}`);
+
+	await copyIcon.click();
+	expect(await notification.getAttribute('style')).toBe('display: block;');
+	await expect(notification).toHaveText('Copied');
+	await baseDriverSteps.checkClipBoardContect(email);
+});
 
 test(
 	qase(
@@ -70,27 +90,10 @@ test(
 	}
 );
 
-test.skip(
-	qase(
-		5025,
-		'Check contact information in "Cooperation Contacts" container from the "Contact Us" page @desktop @mobile @Regression @ContactUs @TSWEB-148'
-	),
-	async () => {
-		const cooperationContactsContainer = driver.getByTestId(ContactUs.Cooperation);
-
-		await expect(cooperationContactsContainer.getByTestId(Container.Email)).toHaveText(
-			'Email\nhello@tech-stack.io'
-		);
-		await expect(cooperationContactsContainer.getByTestId(Container.Phone)).toHaveText(
-			'Phone number\n+1-312-442-0823'
-		);
-	}
-);
-
 test(
 	qase(
 		5003,
-		'Check section number, title and description in "Cooperation Contacts" container from the "Contact Us" page @desktop @mobile @Regression @ContactUs @TSWEB-148'
+		'Check section number, title and description in "Cooperation" container from the "Contact Us" page @desktop @mobile @Regression @ContactUs @TSWEB-148'
 	),
 	async () => {
 		const cooperationContactsContainer = driver.getByTestId(ContactUs.Cooperation);

--- a/ui_tests_playwright/playwright.config.ts
+++ b/ui_tests_playwright/playwright.config.ts
@@ -24,6 +24,8 @@ const config: PlaywrightTestConfig = {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
 		actionTimeout: 10 * 1000,
 		navigationTimeout: 15 * 1000,
+		/* Grant permission to read and write to the clipboard */
+		permissions: ['clipboard-read', 'clipboard-write'],
 		/* Base URL to use in actions like `await page.goto('/')`. */
 		// baseURL: process.env.BASE_URL,
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */


### PR DESCRIPTION
Change and move the contacts block on the Contact Us page:
- add additional number
- change email text 
- make these fields clickable
- add "Copy Email" icon